### PR TITLE
Teach `-t, --tomorrow` and `-y, --yesterday` to skip weekends.

### DIFF
--- a/cmd/scrum/cmd/common.go
+++ b/cmd/scrum/cmd/common.go
@@ -73,6 +73,22 @@ func getScrumClient() (*scrumClient, error) {
 	}, nil
 }
 
+// getTomorrow returns the next weekday.
+//
+// TODO: teach getTomorrow to take in to consideration a vacation schedule.
+func getTomorrow(scrumDate time.Time) time.Time {
+	switch scrumDate.Weekday() {
+	case time.Friday:
+		return scrumDate.AddDate(0, 0, 3)
+	case time.Saturday:
+		return scrumDate.AddDate(0, 0, 2)
+	case time.Sunday:
+		return scrumDate.AddDate(0, 0, 1)
+	default:
+		return scrumDate.AddDate(0, 0, 1)
+	}
+}
+
 func getUser(userKey string) string {
 	switch {
 	case viper.IsSet(userKey):
@@ -93,6 +109,22 @@ func getUser(userKey string) string {
 
 	log.Warn().Msgf("unable to detect a username, please set %q or %q in %q", userKey, configKeyMantaUser, viper.ConfigFileUsed)
 	return ""
+}
+
+// getYesterday returns the previous weekday.
+//
+// TODO: teach getYesterday to take in to consideration a vacation schedule.
+func getYesterday(scrumDate time.Time) time.Time {
+	switch scrumDate.Weekday() {
+	case time.Monday:
+		return scrumDate.AddDate(0, 0, -3)
+	case time.Sunday:
+		return scrumDate.AddDate(0, 0, -2)
+	case time.Saturday:
+		return scrumDate.AddDate(0, 0, -1)
+	default:
+		return scrumDate.AddDate(0, 0, -1)
+	}
 }
 
 func interpolateValue(val string) string {

--- a/cmd/scrum/cmd/get.go
+++ b/cmd/scrum/cmd/get.go
@@ -245,9 +245,9 @@ var getCmd = &cobra.Command{
 
 		switch {
 		case viper.GetBool(configKeyGetTomorrow):
-			scrumDate = scrumDate.AddDate(0, 0, 1)
+			scrumDate = getTomorrow(scrumDate)
 		case viper.GetBool(configKeyGetYesterday):
-			scrumDate = scrumDate.AddDate(0, 0, -1)
+			scrumDate = getYesterday(scrumDate)
 		}
 
 		var w io.Writer

--- a/cmd/scrum/cmd/set.go
+++ b/cmd/scrum/cmd/set.go
@@ -69,9 +69,9 @@ var setCmd = &cobra.Command{
 
 		switch {
 		case viper.GetBool(configKeySetTomorrow):
-			inputScrumDate = inputScrumDate.AddDate(0, 0, 1)
+			inputScrumDate = getTomorrow(inputScrumDate)
 		case viper.GetBool(configKeySetYesterday):
-			inputScrumDate = inputScrumDate.AddDate(0, 0, -1)
+			inputScrumDate = getYesterday(inputScrumDate)
 		}
 
 		// create end date string for vacation and sick time


### PR DESCRIPTION
Potential future work: add support for vacations or holidays.