### PR TITLE
Don't reuse the same viper key across get and set commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Flags:
   -U, --manta-user string        Manta username to scrum as (default "$MANTA_USER")
   -B, --scrum-account string     Manta account for scrum board/files (default "Joyent_Dev")
   -S, --stats                    Log Manta client latency stats on exit (default true)
-      --use-color                Use ASCII colors (default true)
+      --use-color                Use ASCII colors
   -P, --use-pager                Use a $PAGER to read output (defaults to $PAGER, less(1), or more(1)) (default true)
+  -u, --user string              Scrum for specified user (default "$USER")
   -Z, --utc                      Display times in UTC
 
 Use "scrum [command] --help" for more information about a command.
@@ -86,11 +87,10 @@ Examples:
 
 Flags:
   -a, --all                     Get scrum for all users
-  -D, --date string             Date for scrum (default "2018-02-12")
+  -D, --date string             Date for scrum (default "2018-03-12")
   -h, --help                    help for get
   -H, --highlight stringArray   Highlight words definition
   -t, --tomorrow                Get scrum for the next weekday
-  -u, --user string             Get scrum for specified user (default "$USER")
   -y, --yesterday               Get scrum for the previous weekday
 
 Global Flags:
@@ -104,8 +104,9 @@ Global Flags:
   -U, --manta-user string        Manta username to scrum as (default "$MANTA_USER")
   -B, --scrum-account string     Manta account for scrum board/files (default "Joyent_Dev")
   -S, --stats                    Log Manta client latency stats on exit (default true)
-      --use-color                Use ASCII colors (default true)
+      --use-color                Use ASCII colors
   -P, --use-pager                Use a $PAGER to read output (defaults to $PAGER, less(1), or more(1)) (default true)
+  -u, --user string              Scrum for specified user (default "$USER")
   -Z, --utc                      Display times in UTC
 ```
 
@@ -143,14 +144,13 @@ Examples:
   $ scrum set -u other.username -t -i tomorrow.md # Set other.username's scrum for tomorrow
 
 Flags:
-  -D, --date string     Date for scrum (default "2018-02-12")
+  -D, --date string     Date for scrum (default "2018-03-12")
   -d, --days uint       Recycle scrum update for N days
   -i, --file string     File to read scrum from
   -f, --force           Force overwrite of any present scrum
   -h, --help            help for set
   -s, --sick uint       Sick leave for N days
   -t, --tomorrow        Set scrum for the next weekday
-  -u, --user string     Set scrum for specified user (default "$USER")
   -v, --vacation uint   Vacation for N days
 
 Global Flags:
@@ -164,8 +164,9 @@ Global Flags:
   -U, --manta-user string        Manta username to scrum as (default "$MANTA_USER")
   -B, --scrum-account string     Manta account for scrum board/files (default "Joyent_Dev")
   -S, --stats                    Log Manta client latency stats on exit (default true)
-      --use-color                Use ASCII colors (default true)
+      --use-color                Use ASCII colors
   -P, --use-pager                Use a $PAGER to read output (defaults to $PAGER, less(1), or more(1)) (default true)
+  -u, --user string              Scrum for specified user (default "$USER")
   -Z, --utc                      Display times in UTC
 ```
 
@@ -178,13 +179,16 @@ List scrum information for the day
 Usage:
   scrum list [flags]
 
+Aliases:
+  list, ls
+
 Examples:
   $ scrum list                      # List scrummers for the day
   $ scrum list -t
 
 Flags:
   -a, --all           List all metadata details (default true)
-  -D, --date string   Date for scrum (default "2018-02-12")
+  -D, --date string   Date for scrum (default "2018-03-12")
   -h, --help          help for list
   -t, --tomorrow      List scrums for the next weekday
   -1, --usernames     List usernames only
@@ -201,8 +205,9 @@ Global Flags:
   -U, --manta-user string        Manta username to scrum as (default "$MANTA_USER")
   -B, --scrum-account string     Manta account for scrum board/files (default "Joyent_Dev")
   -S, --stats                    Log Manta client latency stats on exit (default true)
-      --use-color                Use ASCII colors (default true)
+      --use-color                Use ASCII colors
   -P, --use-pager                Use a $PAGER to read output (defaults to $PAGER, less(1), or more(1)) (default true)
+  -u, --user string              Scrum for specified user (default "$USER")
   -Z, --utc                      Display times in UTC
 ```
 
@@ -235,8 +240,9 @@ Global Flags:
   -U, --manta-user string        Manta username to scrum as (default "$MANTA_USER")
   -B, --scrum-account string     Manta account for scrum board/files (default "Joyent_Dev")
   -S, --stats                    Log Manta client latency stats on exit (default true)
-      --use-color                Use ASCII colors (default true)
+      --use-color                Use ASCII colors
   -P, --use-pager                Use a $PAGER to read output (defaults to $PAGER, less(1), or more(1)) (default true)
+  -u, --user string              Scrum for specified user (default "$USER")
   -Z, --utc                      Display times in UTC
 % scrum init -f - -Afirst.lastname --manta-key-id=8b:ad:f0:0d:de:ad:be:ef:de:ad:c0:de:ba:dd:ca:fe -Umyuser
 [general]

--- a/cmd/scrum/cmd/get.go
+++ b/cmd/scrum/cmd/get.go
@@ -160,18 +160,6 @@ func init() {
 
 	{
 		const (
-			key               = configKeyScrumUsername
-			longOpt, shortOpt = "user", "u"
-			defaultValue      = "$USER"
-		)
-		flags := getCmd.Flags()
-		flags.StringP(longOpt, shortOpt, defaultValue, "Get scrum for specified user")
-		viper.BindPFlag(key, flags.Lookup(longOpt))
-		viper.SetDefault(key, defaultValue)
-	}
-
-	{
-		const (
 			key               = configKeyGetYesterday
 			longOpt, shortOpt = "yesterday", "y"
 			defaultValue      = false
@@ -308,7 +296,9 @@ var getCmd = &cobra.Command{
 		case viper.GetBool(configKeyGetAll):
 			return getAllScrum(w, client, scrumDate)
 		case !viper.GetBool(configKeyGetAll):
-			return getSingleScrum(w, client, scrumDate, getUser(configKeyScrumUsername), false)
+			username := viper.GetString(configKeyScrumUsername)
+			username = interpolateUserEnvVar(username)
+			return getSingleScrum(w, client, scrumDate, username, false)
 		default:
 			return errors.New("unsupported get mode")
 		}

--- a/cmd/scrum/cmd/init.go
+++ b/cmd/scrum/cmd/init.go
@@ -32,7 +32,7 @@ var initCmd = &cobra.Command{
 		b.WriteString("\n")
 
 		b.WriteString("[scrum]\n")
-		b.WriteString(fmt.Sprintf("manta-account = %+q\n", getUser(configKeyScrumAccount)))
+		b.WriteString(fmt.Sprintf("manta-account = %+q\n", interpolateUserEnvVar(viper.GetString(configKeyScrumAccount))))
 		b.WriteString(fmt.Sprintf("username      = %+q\n", viper.GetString(configKeyScrumUsername)))
 		b.WriteString("\n")
 
@@ -50,7 +50,7 @@ var initCmd = &cobra.Command{
 		b.WriteString("\n")
 
 		b.WriteString("[manta]\n")
-		b.WriteString(fmt.Sprintf("account       = %+q\n", getUser(configKeyMantaAccount)))
+		b.WriteString(fmt.Sprintf("account       = %+q\n", interpolateMantaUserEnvVar(viper.GetString(configKeyMantaAccount))))
 
 		// TODO(seanc@): Pull this value out of the following in order to reduce the
 		// fiction associated with using Manta.
@@ -59,7 +59,7 @@ var initCmd = &cobra.Command{
 		b.WriteString(fmt.Sprintf("key-id        = %+q\n", viper.GetString(configKeyMantaKeyID)))
 		b.WriteString(fmt.Sprintf("timeout       = %+q\n", viper.GetDuration(configKeyMantaTimeout)))
 		b.WriteString(fmt.Sprintf("url           = %+q\n", viper.GetString(configKeyMantaURL)))
-		b.WriteString(fmt.Sprintf("user          = %+q\n", getUser(configKeyMantaUser)))
+		b.WriteString(fmt.Sprintf("user          = %+q\n", interpolateMantaUserEnvVar(viper.GetString(configKeyMantaUser))))
 
 		rawFilename := viper.GetString(configKeyInitFilename)
 		if rawFilename == "-" {

--- a/cmd/scrum/cmd/set.go
+++ b/cmd/scrum/cmd/set.go
@@ -85,7 +85,8 @@ var setCmd = &cobra.Command{
 		for i := 0; i < numDays; i++ {
 			scrumDate := inputScrumDate.AddDate(0, 0, i)
 
-			scrumPath := path.Join("stor", "scrum", scrumDate.Format(scrumDateLayout), getUser(configKeyScrumUsername))
+			username := interpolateUserEnvVar(viper.GetString(configKeyScrumAccount))
+			scrumPath := path.Join("stor", "scrum", scrumDate.Format(scrumDateLayout), username)
 
 			// Check if scrum exists
 			ctx, _ := context.WithTimeout(context.Background(), viper.GetDuration(configKeyMantaTimeout))
@@ -263,18 +264,6 @@ func init() {
 		)
 		flags := setCmd.Flags()
 		flags.BoolP(longOpt, shortOpt, defaultValue, "Set scrum for the next weekday")
-		viper.BindPFlag(key, flags.Lookup(longOpt))
-		viper.SetDefault(key, defaultValue)
-	}
-
-	{
-		const (
-			key               = configKeyScrumUsername
-			longOpt, shortOpt = "user", "u"
-			defaultValue      = "$USER"
-		)
-		flags := setCmd.Flags()
-		flags.StringP(longOpt, shortOpt, defaultValue, "Set scrum for specified user")
 		viper.BindPFlag(key, flags.Lookup(longOpt))
 		viper.SetDefault(key, defaultValue)
 	}


### PR DESCRIPTION
Promote the user command to a global persistent flag.  This was the
original behavior.